### PR TITLE
raising a warning if the element is not found

### DIFF
--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -112,9 +112,6 @@ var mechanic = (function() {
         dom.selector = selector || '';
         if (dom === emptyArray) {
             UIALogger.logWarning("element " + selector + " have not been found");
-        } else {
-            UIALogger.logMessage("element " + selector + " found");
-            dom.log();
         }
         return dom;
     }

--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -110,6 +110,12 @@ var mechanic = (function() {
         dom = dom || emptyArray;
         dom.__proto__ = Z.prototype;
         dom.selector = selector || '';
+        if (dom === emptyArray) {
+            UIALogger.logWarning("element " + selector + " have not been found");
+        } else {
+            UIALogger.logMessage("element " + selector + " found");
+            dom.log();
+        }
         return dom;
     }
 


### PR DESCRIPTION
today, if using UIA to write tests, when the element is not found, nothing is raised, this proved to make things difficult to debug in a test for us.
Just raising a simple warning is already enough.
