### PR TITLE
Added UIANavigationBar and respective shortcut

### DIFF
--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -54,7 +54,8 @@ var mechanic = (function() {
         'UIATextView' : ['textview'],
         'UIAToolbar' : ['toolbar'],
         'UIAWebView' : ['webview'],
-        'UIAWindow' : ['window']
+        'UIAWindow' : ['window'],
+        'UIANavigationBar': ['navigationBar']
     };
 
     // Build a RegExp for picking out type selectors.
@@ -293,7 +294,7 @@ var mechanic = (function() {
                 var els = this.parent().elements().toArray();
                 return els[els.indexOf(this) - 1];
             }), selector);
-        },        
+        },
         index: function(element) {
             return element ? this.indexOf($(element)[0]) : this.parent().elements().toArray().indexOf(this[0]);
         },


### PR DESCRIPTION
Hi! We love your library and make heavy use of it in the open source iOS Testing Framework Appium (https://github.com/appium/appium and https://github.com/appium/appium/wiki/Credits).

Is there any reason why UIANavigationBar wasn't included in the types? If not we'd love to see getting this merged into the code base.

Please let me know if there's anything missing to get this merged.

Keep up the good work!
Sebastian
