### PR TITLE
Multi elements for name based selector

### DIFF
--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -71,15 +71,14 @@ var mechanic = (function() {
     })();
 
     // Add functions to UIAElement to make object graph searching easier.
-    UIAElement.prototype.getElementByName = function(name) {
-        var foundEl = null;
+    UIAElement.prototype.getElementsByName = function(name) {
+        var foundEls = [];
         $.each(this.elements().toArray(), function(idx, el) {
-            if (el.name() === name) foundEl = el;
-            else foundEl = el.getElementByName(name);
-            if (foundEl) return false;
+            if (el.name() === name) foundEls.push(el);
+            else foundEls = foundEls.concat(el.getElementsByName(name));
         });
 
-        return foundEl;
+        return foundEls;
     };
     UIAElement.prototype.getElementsByType = function(type) {
         return $.map(this.elements().toArray(), function(el) {
@@ -130,8 +129,7 @@ var mechanic = (function() {
     $.qsa = $$ = function(element, selector) {
         var found;
         if (idSelectorRE.test(selector)) {
-            found = element.getElementByName(selector.substr(1));
-            return found ? [found] : emptyArray;
+            return element.getElementsByName(selector.substr(1));
         } else if (typeSelectorRE.test(selector)) {
             found = element.getElementsByType(selector);
             return found ? found : emptyArray;


### PR DESCRIPTION
XCode doesn't enforce unique names for buttons (neither caption based nor accessibility labels). There are cases where elements may have same names.
This PR will make sure all of them will get returned.

Let me know if you have questions.

Thanks,
Sebastian
