### PR TITLE
fix crash with Xcode 5 and extra automatic properties

### DIFF
--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -71,8 +71,12 @@ var mechanic = (function() {
         var key;
         var typeSelectorREString = "\\";
         for (key in typeShortcuts) {
-            typeSelectorREString += key + "|";
-            typeShortcuts[key].forEach(function(shortcut) { typeSelectorREString += shortcut + "|"; });
+            // Instruments' javascript runtime (Xcode 5) automatically adds
+            // extra keys which are not in the shortcut list above, skip them
+            if (Array.isArray(typeShortcuts[key])) {
+                typeSelectorREString += key + "|";
+                typeShortcuts[key].forEach(function(shortcut) { typeSelectorREString += shortcut + "|"; });
+            }
         }
         return typeSelectorREString.substr(1, typeSelectorREString.length - 2);
     })();


### PR DESCRIPTION
This addresses issue #30 by skipping the 'dumpProperties' and 'getMethods' keys that get added to the typeShortcuts object (possibly by the Instruments javascript runtime).

I just test for isArray to keep it flexible in case new auto properties get added in the future.
