### PR TITLE
Returning parent before children in getElementsByAttr

### DIFF
--- a/src/mechanic-core.js
+++ b/src/mechanic-core.js
@@ -159,7 +159,7 @@ var mechanic = (function() {
                 val = el[attr]
             if (typeof val == 'function') val = val.apply(el)
             if (typeof val != 'undefined' && val == value)
-              matches.push(el)
+              matches.unshift(el)
             return matches
         })
     }


### PR DESCRIPTION
Same as in getElementsByType, makes selectors easier to use.
