### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[mechanic.js](http://www.cozykozy.com/pages/mechanicjs)  (a CSS-style selector engine for UIAutomation)
+# [mechanic.js](http://www.cozykozy.com/pages/mechanicjs)  (a CSS-style selector engine for UIAutomation)
 
 mechanic.js lets you take the power of UIAutomation with the simplicity of modern javascript CSS selector engines to make your UIAutomation scripts terse and beautiful.
 
@@ -8,7 +8,7 @@ You can also just use it to have fun. Want to click every button in the applicat
 
 [Download mechanic.js](http://www.cozykozy.com/wp-content/uploads/2013/04/mechanic-0.2.zip) and give it a try!
 
-##Features
+## Features
 
 Selecting elements with mechanic.js looks a lot like jQuery, Dojo,
 Zepto, etc. The following will select all `UIAStaticText` elements in the element named "My Scroll View":
@@ -74,11 +74,11 @@ $.prefs({
 });
 ```
 
-###... and more!
+### ... and more!
 
 Mechanic has many more functions to make your life in iOS automation easier. [Read the API documentation](https://github.com/jaykz52/mechanic/wiki) to see just what all can be done with Mechanic.js!
 
-##Extending Mechanic.js
+## Extending Mechanic.js
 
 If there's a feature you're missing, it's easy to extend mechanic with your own "mixins"
 
@@ -104,7 +104,7 @@ $.someAwesomeFeature();
 $("tableview").aNewSelectorMethod();
 ```
 
-##Including Mechanic.js
+## Including Mechanic.js
 
 [Grab a copy of mechanic.js](http://www.cozykozy.com/wp-content/uploads/2013/04/mechanic-0.2.zip) and place it alongside your UIAutomation scripts. At the top of your UIAutomation script(s), import mechanic.js:
 
@@ -116,7 +116,7 @@ mechanic("#some element name").ancestry().capture();
 ...
 ```
 
-##Building
+## Building
 
 You'll need Ruby and Rake to build mechanic. Pull down the repository with git, and run rake:
 
@@ -126,23 +126,23 @@ $ rake
 
 This will concat all of the mechanic modules into 1 file and place it in a "dist" folder. It also outputs a minified version using Google's Closure compiler (which is not entirely important in light of the environment mechanic.js is run under).
 
-##Testing
+## Testing
 
 Progress has been made in writing specs to provide test coverage for mechanic. The specs are jasmine specs, and can only currently be ran in a standalone static html file that serves as the spec runner. I'd like to get to the point where these are ran via jasmine-headless, but in the meantime you can run the tests by opening spec/runner.html in any modern browser.
 
 To add additional specs, you can either append the specs to an existing spec file (there is a spec for each module), or you can create a separate spec and add a script tag pointing to the new spec in spec/runner.html
 
-##Feature Requests/Bugs
+## Feature Requests/Bugs
 
 Mechanic is not perfect. Submit bugs and feature requests if there's something that you think is missing! If you encounter bugs, please report it on mechanic's Issues page: http://github.com/jaykz52/mechanic/issues
 
 If you've got a fix in mind, fork and submit a pull request. We need contributors!
 
-##Contributing
+## Contributing
 
 The project is currently in its infancy. We need API documentation, additional features, and test coverage (!!!), so feel free to get in touch via github, or just start submitting patches! Try to keep patches to single issues, this will make our lives easier in the long term. If you or your organization is interested in adopting mechanic.js and have questions, feel free to contact Jason at jason.kozemcak@gmail.com
 
-##License
+## License
 
 Copyright (c) 2012 Jason Kozemczak
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
